### PR TITLE
Fix too many GBK files

### DIFF
--- a/ampcombi/ampcombi.py
+++ b/ampcombi/ampcombi.py
@@ -337,6 +337,9 @@ def process_sample(
     # parse gene bank file and filter for contig IDs with stop codons, if applicable (grabs contig IDs, and extract filetred gbks)
     if write_gbk:
         outgbk = os.path.join(sample, sample + '_filtered_AMP_contigs.gbk')
+        if os.path.isfile(outgbk):
+            print(f"Warning: The file {outgbk} already exists. I will rename the original file to avoid a file collision.")
+            os.rename(outgbk, outgbk + ".bak")
     else:
         outgbk = None
     print(f'Parsing the corresponding gene bank file for {sample} ....')

--- a/ampcombi/ampcombi.py
+++ b/ampcombi/ampcombi.py
@@ -72,8 +72,8 @@ parse_all_parser.add_argument("--window_size_stop_codon", dest="stopwindowsize",
                     type=int, default=60)
 parse_all_parser.add_argument("--window_size_transporter", dest="transporterwindowsize", help="Enter the length of the window size required to look for a 'transporter' e.g. ABC transporter downstream and upstream of the CDS hits. \n (default: %(default)s)",
                     type=int, default=11)
-parse_all_parser.add_argument("--remove_stop_codons", dest="removestops", help="Removes any hits/CDSs that don't have a stop codon found in the window below or upstream of the CDS assigned by '--window_size_stop_codon'. Must be turned on if hits are to be removed. \n (default: %(default)s)",
-                    type=bool, default=False)
+parse_all_parser.add_argument("--remove_stop_codons", dest="removestops", help="Switch on to remove any hits/CDSs that don't have a stop codon found in the window below or upstream of the CDS assigned by '--window_size_stop_codon'. Must be turned on if hits are to be removed.\n (default: --no-remove_stop_codons)",
+                    action=argparse.BooleanOptionalAction, default=False)
 parse_all_parser.add_argument("--faa", dest="faa", help="Enter the path to the folder containing the reference .faa files or to one .faa file (running only one sample). Filenames have to contain the corresponding sample-name, i.e. sample_1.faa \n (default: %(default)s)",
                     type=str, default='./test_faa/')
 parse_all_parser.add_argument("--gbk", dest="gbk", help="Enter the path to the folder containing the reference .gbk/.gbff files or to one .gbk/.gbff file (running only one sample). Filenames have to contain the corresponding sample-name, i.e. sample_1.gbk/ sample_1.gbff \n (default: %(default)s)",
@@ -106,8 +106,10 @@ parse_all_parser.add_argument("--sample_metadata", dest="samplemetadata", help="
                     type=str, default=None)
 parse_all_parser.add_argument("--contig_metadata", dest="contigmetadata", help="Path to a tsv-file containing contig metadata, e,g, 'path/to/contig_metadata.tsv'. The metadata table can have more information for contig classification that will be added to the output summary. The table needs to contain the sample names in the first column and the contig_ID in the second column. This can be the output from MMseqs2, pydamage and MetaWrap. \n (default: %(default)s)",
                     type=str, default=None)
-parse_all_parser.add_argument("--log", dest="log_file", nargs='?', help="Silences the standard output and captures it in a log file)",
-                    type=bool, default=False)
+parse_all_parser.add_argument("--write_gbk", dest="write_gbk", help="Switch on to write a GBK file to disk containing contigs of filtered AMPs (e.g. if they include stop codons and transporter proteins in the vicinity).\n (default: --no-write_gbk)",
+                    action=argparse.BooleanOptionalAction, default=False)
+parse_all_parser.add_argument("--log", dest="log_file", help="Switch on to silence the standard output and capture it in a log file.\n (default: --no-log)",
+                    action=argparse.BooleanOptionalAction, default=False)
 parse_all_parser.add_argument("--threads", dest="cores", nargs='?', help="Changes the threads used for DIAMOND alignment (default: %(default)s)",
                     type=int, default=4)
 parse_all_parser.add_argument('--version', action='version', version='ampcombi' + __version__)
@@ -121,8 +123,8 @@ complete_parser.add_argument("--summaries_directory", dest="summarydir", nargs='
                     type=str)
 complete_parser.add_argument("--summaries_files", dest="summaryfile", nargs='+', help="Enter a list of samples' ampcombi summaries, e.g. ./ampcombi/sample_1/sample_1_ampcombi.tsv ./ampcombi/sample_2_ampcombi.tsv",
                     type=str)
-complete_parser.add_argument("--log", dest="log_file", nargs='?', help="Silences the standard output and captures it in a log file)",
-                    type=bool, default=False)
+complete_parser.add_argument("--log", dest="log_file", help="Switch on to silence the standard output and capture it in a log file.\n (default: --no-log)",
+                    action=argparse.BooleanOptionalAction, default=False)
 complete_parser.add_argument('--version', action='version', version='ampcombi' + __version__)
 
 #########################################
@@ -142,16 +144,16 @@ cluster_parser.add_argument("--cluster_seq_id", dest="mmseqsseqid", nargs='?', h
                     type=float, default=0.4)
 cluster_parser.add_argument("--cluster_sensitivity", dest="mmseqssensitivity", nargs='?', help="This assigns sensitivity of alignment to the mmseqs2 cluster module- More information can be obtained in mmseqs2 docs at https://mmseqs.com/latest/userguide.pdf",
                     type=float, default=4.0)
-cluster_parser.add_argument("--cluster_remove_singletons", dest="removesingletons", nargs='?', help="This removes any hits that did not form a cluster",
-                    type=bool, default=True)
+cluster_parser.add_argument("--cluster_remove_singletons", dest="removesingletons", help="Switch off to keep any hits that did not form a cluster\n (default: --cluster_remove_singletons)",
+                    action=argparse.BooleanOptionalAction, default=True)
 cluster_parser.add_argument("--cluster_retain_label", dest="retainlabels", nargs='?', help="This removes any cluster that only has a certain label in the sample name. For example if you have samples labels with 'S1_metaspades' and 'S1_megahit', you can retain clusters that have samples with suffix '_megahit' by running '--retain_clusters_label megahit'",
                     type=str, default='')
 cluster_parser.add_argument("--cluster_min_member", dest="minnumber", nargs='?', help="This removes any cluster that has a hit number lower than this",
                     type=int, default=2)
 cluster_parser.add_argument("--threads", dest="cores", nargs='?', help="Changes the threads used for DIAMOND alignment (default: %(default)s)",
                     type=int, default=4)
-cluster_parser.add_argument("--log", dest="log_file", nargs='?', help="Silences the standard output and captures it in a log file)",
-                    type=bool, default=False)
+cluster_parser.add_argument("--log", dest="log_file", help="Switch on to silence the standard output and capture it in a log file.\n (default: --no-log)",
+                    action=argparse.BooleanOptionalAction, default=False)
 cluster_parser.add_argument('--version', action='version', version='ampcombi' + __version__)
 
 #########################################
@@ -163,8 +165,8 @@ signalp_parser.add_argument("--ampcombi_cluster", dest="clustersummary", nargs='
                     type=str, default='./Ampcombi_summary_cluster.tsv')
 signalp_parser.add_argument("--signalp_model", dest="signalpmodels", nargs='?', help="Enter a directory path corresponding to the signalp models. More information can be found in signalp documentation at https://services.healthtech.dtu.dk/services/SignalP-6.0/",
                     type=str, default='./models/')
-signalp_parser.add_argument("--log", dest="log_file", nargs='?', help="Silences the standard output and captures it in a log file)",
-                    type=bool, default=False)
+signalp_parser.add_argument("--log", dest="log_file", help="Switch on to silence the standard output and capture it in a log file.\n (default: --no-log)",
+                    action=argparse.BooleanOptionalAction, default=False)
 signalp_parser.add_argument('--version', action='version', version='ampcombi' + __version__)
 
 #########################################
@@ -209,6 +211,7 @@ def parse_tables(args):
     interpro_filter_values = args.interpro_remove
     add_samplemetadata = args.samplemetadata
     add_contigmetadata = args.contigmetadata
+    write_gbk = args.write_gbk
     threads = args.cores
 
     # additional variables
@@ -259,14 +262,14 @@ def parse_tables(args):
                     sample, filepaths[i], amp_faa_paths, db, threads, dbevalue, p, 
                     hmmevalue, tooldict, faa_path, gbk_dir, interpro_dir, interpro_filter_values, 
                     aa_len, stop_codon_window, transporter_window, filter_stop_codon, add_samplemetadata, 
-                    add_contigmetadata)
+                    add_contigmetadata, write_gbk)
             shutil.move(log_file_t, os.path.join(sample, log_file_t))
         else:
             process_sample(
                 sample, filepaths[i], amp_faa_paths, db, threads, dbevalue, p, 
                 hmmevalue, tooldict, faa_path, gbk_dir, interpro_dir, interpro_filter_values, 
                 aa_len, stop_codon_window, transporter_window, filter_stop_codon, add_samplemetadata, 
-                add_contigmetadata)
+                add_contigmetadata, write_gbk)
 
     # remove the temp directory if it exists
     if os.path.exists('./temp'):
@@ -275,7 +278,7 @@ def parse_tables(args):
 def process_sample(
     sample, filepaths, amp_faa_paths, db, threads, dbevalue, p, hmmevalue, tooldict, faa_path, gbk_dir, 
     interpro_dir, interpro_filter_values, aa_len, stop_codon_window, transporter_window, filter_stop_codon, 
-    add_samplemetadata, add_contigmetadata):
+    add_samplemetadata, add_contigmetadata, write_gbk):
     """
     This parses, filters and aligns the antimicrobial peptides sample by sample. 
     It extensively uses pandas, BioPython to parse tables and retrieve details like physiochemical
@@ -332,8 +335,10 @@ def process_sample(
     sample_summary_df = sample_summary_df_functions
 
     # parse gene bank file and filter for contig IDs with stop codons, if applicable (grabs contig IDs, and extract filetred gbks)
-    outgbk = os.path.join(sample, 'contig_gbks')
-    os.makedirs(outgbk, exist_ok=True)
+    if write_gbk:
+        outgbk = os.path.join(sample, 'filtered_AMP_contigs.gbk')
+    else:
+        outgbk = None
     print(f'Parsing the corresponding gene bank file for {sample} ....')
     sample_summary_df = gbkparsing(sample_summary_df, gbk_name, stop_codon_window, transporter_window, filter_stop_codon, outgbk)
 

--- a/ampcombi/ampcombi.py
+++ b/ampcombi/ampcombi.py
@@ -72,8 +72,8 @@ parse_all_parser.add_argument("--window_size_stop_codon", dest="stopwindowsize",
                     type=int, default=60)
 parse_all_parser.add_argument("--window_size_transporter", dest="transporterwindowsize", help="Enter the length of the window size required to look for a 'transporter' e.g. ABC transporter downstream and upstream of the CDS hits. \n (default: %(default)s)",
                     type=int, default=11)
-parse_all_parser.add_argument("--remove_stop_codons", dest="removestops", help="Switch on to remove any hits/CDSs that don't have a stop codon found in the window below or upstream of the CDS assigned by '--window_size_stop_codon'. Must be turned on if hits are to be removed.\n (default: --no-remove_stop_codons)",
-                    action=argparse.BooleanOptionalAction, default=False)
+parse_all_parser.add_argument("--remove_stop_codons", dest="removestops", help="Remove any hits/CDSs that don't have a stop codon found in the window below or upstream of the CDS assigned by '--window_size_stop_codon'. Must be turned on if hits are to be removed.",
+                    action="store_true")
 parse_all_parser.add_argument("--faa", dest="faa", help="Enter the path to the folder containing the reference .faa files or to one .faa file (running only one sample). Filenames have to contain the corresponding sample-name, i.e. sample_1.faa \n (default: %(default)s)",
                     type=str, default='./test_faa/')
 parse_all_parser.add_argument("--gbk", dest="gbk", help="Enter the path to the folder containing the reference .gbk/.gbff files or to one .gbk/.gbff file (running only one sample). Filenames have to contain the corresponding sample-name, i.e. sample_1.gbk/ sample_1.gbff \n (default: %(default)s)",
@@ -106,10 +106,10 @@ parse_all_parser.add_argument("--sample_metadata", dest="samplemetadata", help="
                     type=str, default=None)
 parse_all_parser.add_argument("--contig_metadata", dest="contigmetadata", help="Path to a tsv-file containing contig metadata, e,g, 'path/to/contig_metadata.tsv'. The metadata table can have more information for contig classification that will be added to the output summary. The table needs to contain the sample names in the first column and the contig_ID in the second column. This can be the output from MMseqs2, pydamage and MetaWrap. \n (default: %(default)s)",
                     type=str, default=None)
-parse_all_parser.add_argument("--write_gbk", dest="write_gbk", help="Switch on to write a GBK file to disk containing contigs of filtered AMPs (e.g. if they include stop codons and transporter proteins in the vicinity).\n (default: --no-write_gbk)",
-                    action=argparse.BooleanOptionalAction, default=False)
-parse_all_parser.add_argument("--log", dest="log_file", help="Switch on to silence the standard output and capture it in a log file.\n (default: --no-log)",
-                    action=argparse.BooleanOptionalAction, default=False)
+parse_all_parser.add_argument("--write_gbk", dest="write_gbk", help="Write a GBK file to disk containing all contigs of filtered AMPs (e.g. if they include stop codons and transporter proteins in the vicinity).",
+                    action="store_true")
+parse_all_parser.add_argument("--log", dest="log_file", help="Silence the standard output and capture it in a log file.",
+                    action="store_true")
 parse_all_parser.add_argument("--threads", dest="cores", nargs='?', help="Changes the threads used for DIAMOND alignment (default: %(default)s)",
                     type=int, default=4)
 parse_all_parser.add_argument('--version', action='version', version='ampcombi' + __version__)
@@ -123,8 +123,8 @@ complete_parser.add_argument("--summaries_directory", dest="summarydir", nargs='
                     type=str)
 complete_parser.add_argument("--summaries_files", dest="summaryfile", nargs='+', help="Enter a list of samples' ampcombi summaries, e.g. ./ampcombi/sample_1/sample_1_ampcombi.tsv ./ampcombi/sample_2_ampcombi.tsv",
                     type=str)
-complete_parser.add_argument("--log", dest="log_file", help="Switch on to silence the standard output and capture it in a log file.\n (default: --no-log)",
-                    action=argparse.BooleanOptionalAction, default=False)
+complete_parser.add_argument("--log", dest="log_file", help="Silence the standard output and capture it in a log file.",
+                    action="store_true")
 complete_parser.add_argument('--version', action='version', version='ampcombi' + __version__)
 
 #########################################
@@ -152,8 +152,8 @@ cluster_parser.add_argument("--cluster_min_member", dest="minnumber", nargs='?',
                     type=int, default=2)
 cluster_parser.add_argument("--threads", dest="cores", nargs='?', help="Changes the threads used for DIAMOND alignment (default: %(default)s)",
                     type=int, default=4)
-cluster_parser.add_argument("--log", dest="log_file", help="Switch on to silence the standard output and capture it in a log file.\n (default: --no-log)",
-                    action=argparse.BooleanOptionalAction, default=False)
+cluster_parser.add_argument("--log", dest="log_file", help="Silence the standard output and capture it in a log file.",
+                    action="store_true")
 cluster_parser.add_argument('--version', action='version', version='ampcombi' + __version__)
 
 #########################################
@@ -165,8 +165,8 @@ signalp_parser.add_argument("--ampcombi_cluster", dest="clustersummary", nargs='
                     type=str, default='./Ampcombi_summary_cluster.tsv')
 signalp_parser.add_argument("--signalp_model", dest="signalpmodels", nargs='?', help="Enter a directory path corresponding to the signalp models. More information can be found in signalp documentation at https://services.healthtech.dtu.dk/services/SignalP-6.0/",
                     type=str, default='./models/')
-signalp_parser.add_argument("--log", dest="log_file", help="Switch on to silence the standard output and capture it in a log file.\n (default: --no-log)",
-                    action=argparse.BooleanOptionalAction, default=False)
+signalp_parser.add_argument("--log", dest="log_file", help="Silence the standard output and capture it in a log file.",
+                    action="store_true")
 signalp_parser.add_argument('--version', action='version', version='ampcombi' + __version__)
 
 #########################################
@@ -336,7 +336,7 @@ def process_sample(
 
     # parse gene bank file and filter for contig IDs with stop codons, if applicable (grabs contig IDs, and extract filetred gbks)
     if write_gbk:
-        outgbk = os.path.join(sample, 'filtered_AMP_contigs.gbk')
+        outgbk = os.path.join(sample, sample + '_filtered_AMP_contigs.gbk')
     else:
         outgbk = None
     print(f'Parsing the corresponding gene bank file for {sample} ....')

--- a/ampcombi/ampcombi.py
+++ b/ampcombi/ampcombi.py
@@ -144,8 +144,8 @@ cluster_parser.add_argument("--cluster_seq_id", dest="mmseqsseqid", nargs='?', h
                     type=float, default=0.4)
 cluster_parser.add_argument("--cluster_sensitivity", dest="mmseqssensitivity", nargs='?', help="This assigns sensitivity of alignment to the mmseqs2 cluster module- More information can be obtained in mmseqs2 docs at https://mmseqs.com/latest/userguide.pdf",
                     type=float, default=4.0)
-cluster_parser.add_argument("--cluster_remove_singletons", dest="removesingletons", help="Switch off to keep any hits that did not form a cluster\n (default: --cluster_remove_singletons)",
-                    action=argparse.BooleanOptionalAction, default=True)
+cluster_parser.add_argument("--cluster_keep_singletons", dest="keepsingletons", help="This keeps any hits that did not form a cluster",
+                    action="store_true")
 cluster_parser.add_argument("--cluster_retain_label", dest="retainlabels", nargs='?', help="This removes any cluster that only has a certain label in the sample name. For example if you have samples labels with 'S1_metaspades' and 'S1_megahit', you can retain clusters that have samples with suffix '_megahit' by running '--retain_clusters_label megahit'",
                     type=str, default='')
 cluster_parser.add_argument("--cluster_min_member", dest="minnumber", nargs='?', help="This removes any cluster that has a hit number lower than this",
@@ -415,7 +415,7 @@ def cluster(args):
     coverage = args.mmseqscoverage
     seq_id = args.mmseqsseqid
     sensitivity = args.mmseqssensitivity
-    remove_singletons = args.removesingletons
+    keep_singletons = args.keepsingletons
     min_cluster_members = args.minnumber
     retain_clusters_with = args.retainlabels
     threads = args.cores
@@ -424,7 +424,7 @@ def cluster(args):
     ampcombi_summary_df = pd.read_csv(ampcombi_summary, delimiter='\t')
     merged_df = parsing_input_for_cluster(ampcombi_summary_df)
     mmseqs_cluster(cov_mod,cluster_mode,coverage,seq_id,sensitivity,threads)
-    compile_clusters(merged_df,retain_clusters_with,remove_singletons,min_cluster_members)
+    compile_clusters(merged_df,retain_clusters_with,keep_singletons,min_cluster_members)
     print(f'\n DONE: Ampcombi_summary_cluster.tsv and AMPcombi_summary_cluster_representative_seq.tsv were saved to your current working directory.')
     print('\n ########################################################## ')
 

--- a/ampcombi/clustering_hits.py
+++ b/ampcombi/clustering_hits.py
@@ -71,7 +71,7 @@ def mmseqs_cluster(cov_mod,cluster_mode,coverage,seq_id,sensitivity,threads):
 ########################################
 # FUNCTION: COMPILE THE CLUSTERS IN TABLE
 #########################################
-def compile_clusters(merged_df,retain_clusters_with, remove_singletons, min_cluster_members):
+def compile_clusters(merged_df,retain_clusters_with, keep_singletons, min_cluster_members):
     # collect the clusters in a list and df
     cluster = "./clusters/sequenceDBclu.tsv"
     clusters = pd.read_csv(cluster, sep='\t', header=None)
@@ -149,7 +149,7 @@ def compile_clusters(merged_df,retain_clusters_with, remove_singletons, min_clus
     shutil.rmtree('./tmp')
     
     # remove singletons (= None)
-    if remove_singletons == True:
+    if keep_singletons == False:
         ampcombi_cluster = ampcombi_cluster.dropna(subset=['cluster_id'])
 
     # remove cds_ID to grab only the gbk files corresponding to the dereplicated hits 

--- a/ampcombi/parse_gbks.py
+++ b/ampcombi/parse_gbks.py
@@ -55,7 +55,9 @@ def gbk_parse(gbk_dir, stop_codon_window, ampcombi_dict_mod, transporter_window,
     # Window size for searching before the start and end positions
     window_size = stop_codon_window
     # Step size for sliding the window
-    window_step = 3 
+    window_step = 3
+    # Initialize variable for later checks
+    prev_seq_record_id = ""
     
     # look for the file name with correct ampcombi sample
     for d in ampcombi_dict_mod:
@@ -170,21 +172,24 @@ def gbk_parse(gbk_dir, stop_codon_window, ampcombi_dict_mod, transporter_window,
                                     #print(f"Codon sequence '{stop_minus}' not found in the window up and down stream of the hit '{start}'") 
                                     dict['CDS_stop_codon_found'] = 'no'
                                 listdict.append(dict.copy())
-            
+
             # if flagged remove hits with no stop codons found
             if filter_stop_codon == True:
                 listdict = [d for d in listdict if d.get('CDS_stop_codon_found') != 'no']
         
             #########
-            #  Step3: Extract the new gbks that contain the hits
+            #  Step3: Extract the new gbks that contain the hits if flag write_gbk is activated
             #########
-            for item in listdict:
-                if item['name'] and item['contig_name'] == record.id:
-                    name = item['name']
-                    contig_name = item['contig_name']
-                    new_seq_record = record
-                    print(f'writing {name}_{contig_name}.gbk')
-                    SeqIO.write(new_seq_record, f'{outgbk}/{name}_{contig_name}.gbk', "genbank")
+            if outgbk:
+                with open(outgbk,"a") as out_gbk:
+                    for item in listdict:
+                        if item['name'] and item['contig_name'] == record.id and record.id != prev_seq_record_id:
+                            name = item['name']
+                            contig_name = item['contig_name']
+                            prev_seq_record_id = record.id
+                            new_seq_record = record
+                            print(f'writing {name}_{contig_name}.gbk')
+                            SeqIO.write(new_seq_record, out_gbk, "genbank")
 
     return listdict
 

--- a/ampcombi/parse_gbks.py
+++ b/ampcombi/parse_gbks.py
@@ -188,7 +188,7 @@ def gbk_parse(gbk_dir, stop_codon_window, ampcombi_dict_mod, transporter_window,
                             contig_name = item['contig_name']
                             prev_seq_record_id = record.id
                             new_seq_record = record
-                            print(f'writing {name}_{contig_name}.gbk')
+                            print(f'Adding contig {contig_name} of sample {name} to GBK file.')
                             SeqIO.write(new_seq_record, out_gbk, "genbank")
 
     return listdict

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -185,6 +185,10 @@ In this case, we use the ``--path_list`` option to supply AMP tool prediction re
      - Path to a tsv-file containing contig metadata, e.g. 'path/to/contig_metadata.tsv'. The metadata table can have more information for contig classification that will be added to the output summary. The table needs to contain the sample names in the first column and the contig_ID in the second column. The metadata table can be the output from MMseqs2, pydamage, and MetaWrap.
      - None
      - ./contig_metadata.tsv/
+   * - **--write_gbk**
+     - Write a GBK file to disk containing contigs of filtered AMPs (e.g. if they include stop codons and transporter proteins in the vicinity).
+     - None
+     - None
    * - **--interproscan_filter**
      - A comma-separated list of all keywords that describe the protein that is not required in the analysis.
      - 'ribosomal protein,ribosomal proteins,ribosome protein,ribosomal rna,Ribosomal protein,RIBOSOMAL PROTEIN'


### PR DESCRIPTION
This fixes #106 (and might be related to [#505](https://github.com/nf-core/funcscan/issues/505)).

- Instead of one GBK file per contig for the filtered AMPs, a single concatenated GBK file is written to disk
- Writing the GBK file is optional and turned off by default

I made it optional/turned it off because the GBK files are not being used anywhere in the code. I assume the original idea was to have the contigs as files for manual inspection by the user. This option still exists now by switching the `--write_gbk` flag on.